### PR TITLE
fix owner/repo extraction for ssh origins

### DIFF
--- a/src/rooster/_github.py
+++ b/src/rooster/_github.py
@@ -111,12 +111,18 @@ def parse_remote_url(remote_url: str) -> tuple[str, str]:
     """
     Parse a Git remote URL into owner and repository components.
     """
-    parts = remote_url.split("/")
-    owner = parts[-2]
-    repo = parts[-1]
-    if repo.endswith(".git"):
-        repo = repo[:-4]
-    return owner, repo
+    ssh_prefix = 'git@github.com:'
+    if remote_url.startswith(ssh_prefix):
+        owner_slash_repo = remote_url[len(ssh_prefix):]
+        owner, repo = owner_slash_repo.split('/')
+        return owner, repo
+    else:
+        parts = remote_url.split("/")
+        owner = parts[-2]
+        repo = parts[-1]
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return owner, repo
 
 
 def get_pull_requests_for_commits(

--- a/src/rooster/_github.py
+++ b/src/rooster/_github.py
@@ -111,10 +111,10 @@ def parse_remote_url(remote_url: str) -> tuple[str, str]:
     """
     Parse a Git remote URL into owner and repository components.
     """
-    ssh_prefix = 'git@github.com:'
+    ssh_prefix = "git@github.com:"
     if remote_url.startswith(ssh_prefix):
-        owner_slash_repo = remote_url[len(ssh_prefix):]
-        owner, repo = owner_slash_repo.split('/')
+        owner_slash_repo = remote_url[len(ssh_prefix) :]
+        owner, repo = owner_slash_repo.split("/")
         return owner, repo
     else:
         parts = remote_url.split("/")


### PR DESCRIPTION
We do some quick detection of the SSH origin, and if so, use slightly different logic to extract the owner and name of the remote.