### PR TITLE
Fix ssh urls

### DIFF
--- a/src/rooster/_github.py
+++ b/src/rooster/_github.py
@@ -115,14 +115,13 @@ def parse_remote_url(remote_url: str) -> tuple[str, str]:
     if remote_url.startswith(ssh_prefix):
         owner_slash_repo = remote_url[len(ssh_prefix) :]
         owner, repo = owner_slash_repo.split("/")
-        return owner, repo
     else:
         parts = remote_url.split("/")
         owner = parts[-2]
         repo = parts[-1]
-        if repo.endswith(".git"):
-            repo = repo[:-4]
-        return owner, repo
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return owner, repo
 
 
 def get_pull_requests_for_commits(


### PR DESCRIPTION
When the remote url starts with git@..., rooster fails to find the repo with the following message:

```
RuntimeError: GraphQL server responded with error: [{'type': 'NOT_FOUND', 'path': ['repository'], 'locations': [{'line': 5, 'column': 5}], 'message': "Could not resolve to a Repository with the name 'karpetrosyan/hishel.git'."}]
```
