### PR TITLE
Properly parse JSON in caching logic

### DIFF
--- a/src/rooster/_cache.py
+++ b/src/rooster/_cache.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 import os
 
 import hishel
@@ -16,7 +15,12 @@ class GraphQLCacheController(hishel.Controller):
         # Since GraphQL always returns a 200, we check the response body for errors
         error_in_response_body = False
         try:
-            error_in_response_body = json.loads(response.read()).get("errors")
+            cooked_response = httpx.Response(
+                status_code=response.status,
+                headers=response.headers,
+                content=response.content,
+            )
+            error_in_response_body = cooked_response.json().get("errors")
         except Exception:
             pass  # The response cannot be parsed as JSON
         return super().is_cachable(request, response) and not error_in_response_body


### PR DESCRIPTION
Hishel works with httpcore.Response, not httpx.Response, which doesn't do e.g. gzip decoding. In order to correctly parse the JSON we have to construct an httpx.Response (which Hishel will do later but not at the point where we need it).

Without this, responses containing a JSON list of errors are incorrectly cached.